### PR TITLE
Init kcache at runtime instead of static block

### DIFF
--- a/src/core/utils/JitHelper.cpp
+++ b/src/core/utils/JitHelper.cpp
@@ -16,7 +16,7 @@
 #include "RuntimeData.h"
 #include "JitHelper.h"
 
-jitify::JitCache JitHelper::kcache;
+jitify::JitCache* JitHelper::kcache = nullptr;
 
 const std::filesystem::path JitHelper::KERNEL_DIR = DEMERuntimeDataHelper::data_path / "kernel";
 const std::filesystem::path JitHelper::KERNEL_INCLUDE_DIR = DEMERuntimeDataHelper::include_path;
@@ -82,5 +82,8 @@ jitify::Program JitHelper::buildProgram(
     }
     */
 
-    return kcache.program(code, header_code, flags);
+    if(kcache==nullptr)
+        kcache = new jitify::JitCache();
+
+    return kcache->program(code, header_code, flags);
 }

--- a/src/core/utils/JitHelper.h
+++ b/src/core/utils/JitHelper.h
@@ -48,7 +48,7 @@ class JitHelper {
     static const std::filesystem::path KERNEL_INCLUDE_DIR;
 
   private:
-    static jitify::JitCache kcache;
+    static jitify::JitCache* kcache;
 
     inline static std::string loadSourceFile(const std::filesystem::path& sourcefile) {
         std::string code;


### PR DESCRIPTION
This PR is necessary for DEM-Engine to successfully run on certain combination of Windows version and CUDA version. On Windows 11 25H2 and CUDA 12.8, creating `JitCache` objects in the static block will result in freeze on native Windows (not WSL). 

Check https://github.com/rapidsai/cudf/issues/1950 for reference. 