### PR TITLE
CMAKE_CXX_FLAGS corruption in FixNinjaColors.cmake

### DIFF
--- a/cmake/FixNinjaColors.cmake
+++ b/cmake/FixNinjaColors.cmake
@@ -36,17 +36,16 @@ function(fix_ninja_colors)
 		# Fix GCC colors
 		if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
 			#set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-fdiagnostics-color=always" PARENT_SCOPE)
-			list(APPEND CMAKE_CXX_FLAGS "-fdiagnostics-color=always")	
+			string(APPEND CMAKE_CXX_FLAGS " -fdiagnostics-color=always")	
 
 		# Fix Clang colors
 		elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
 			#set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-fcolor-diagnostics" PARENT_SCOPE)
-			list(APPEND CMAKE_CXX_FLAGS "-fcolor-diagnostics")
+			string(APPEND CMAKE_CXX_FLAGS " -fcolor-diagnostics")
 
 		endif()
 		
-		list(REMOVE_DUPLICATES CMAKE_CXX_FLAGS)
-		set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} PARENT_SCOPE)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" PARENT_SCOPE)
 	endif()
 
 endfunction()


### PR DESCRIPTION
list(APPEND) treats CMAKE_CXX_FLAGS as a semicolon-separated list, so when the variable is non-empty (any toolchain that exports CXXFLAGS, e.g. conda) the generated Ninja compile command contains
"...;-fdiagnostics-color=always". The shell runs the text after the semicolon as a separate command: every C++ TU fails with "fatal error: no input files" and the flag itself fails with "not found" (exit 127). With empty flags the list-append degenerates to a plain append, which is why default builds never see it.

string(APPEND) with a leading space preserves the intent in both the GCC and Clang branches. The final PARENT_SCOPE set is quoted for the same reason, and the REMOVE_DUPLICATES call is dropped because it only ever did anything on the semicolon-list form.

Reproduced on Ubuntu 24.04 with CMake 4.2.3, Ninja, and a conda-forge gcc/nvcc toolchain; after the change the same tree configures and builds clean.